### PR TITLE
changes to be more compatible with pre-prepared image

### DIFF
--- a/examples/Makefile.beaglewire
+++ b/examples/Makefile.beaglewire
@@ -1,3 +1,4 @@
+# -*- makefile -*-
 .PHONY: all load clean
 
 DEVICE = 8k
@@ -22,10 +23,13 @@ $(PROJ).blif: $(SRC)
 
 %.bin: %.asc
 	time icepack $^ $@
-	echo -e "\x0\x0\x0\x0\x0\x0\x0" >> $@
+	/bin/echo -n -e '\x0\x0\x0\x0\x0\x0\x0\x0' >> $@
 
 %.load: %.bin
 	dd if=$< of=/dev/spidev1.0
+
+%.bw-prog: %.bin
+	sh /home/debian/load-fw/bw-prog.sh ./$^
 
 clean:
 	$(RM) *.blif *.asc *.bin


### PR DESCRIPTION
  - pre-made image instructions here:
    https://elinux.org/BeagleBoard/BeagleWire#Use_pre-prepared_BBB_image

  - explicitly set path to /bin/echo

    - before this, appends literal string, instead of the desired NUL
      characters

    - also use `-n` to avoid implicit addition of newline, and added another
      NUL char to bring total to eight

  - add a .bw-prog target to use the uploader method/script found in
    pre-prepared image